### PR TITLE
fix: skip valculator-app in lerna version to avoid duplicate tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         git config user.name "${{ github.actor }}"
         git config user.email "${{ github.actor}}@users.noreply.github.com"
-        npx lerna version --conventional-commits --yes
+        npx lerna version --conventional-commits --yes --ignore '@studio-helga/valculator-app'
         
     - name: Install Dependencies
       run: yarn install
@@ -40,6 +40,6 @@ jobs:
       run: yarn build
 
     - name: Publish
-      run: npx lerna publish from-package --yes
+      run: npx lerna publish from-package --yes --ignore '@studio-helga/valculator-app'
       env: 
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,8 @@
   "command": {
     "version": {
       "allowBranch": ["main"],
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "ignoreChanges": ["packages/interface/**"]
     }
   }
 }

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,12 +1,10 @@
 {
   "name": "@studio-helga/valculator-app",
   "author": "Charlotte Hughes <hues.charlotte@gmail.com>",
+  "private": true,
   "version": "1.0.0",
   "type": "module",
   "main": "dist/entry-interface.js",
-  "publishConfig": {
-    "access": "public"
-  },
   "exports": {
     ".": {
       "import": "./dist/entry-interface.js",

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.2](https://github.com/charlotte-hues/valculator/compare/@valculator/theme@0.3.1...@valculator/theme@0.3.2) (2026-07-16)
+
+
+### Bug Fixes
+
+* publish [@valculator](https://github.com/valculator) packages to npmjs.org ([110daa1](https://github.com/charlotte-hues/valculator/commit/110daa180ac329aa6ab37c571314a72d55748135))
+
+
+
+
+
 ## [0.3.1](https://github.com/charlotte-hues/valculator/compare/@valculator/theme@0.3.0...@valculator/theme@0.3.1) (2026-07-16)
 
 **Note:** Version bump only for package @valculator/theme

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valculator/theme",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "main": "src/main.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Exclude unused `@studio-helga/valculator-app` from Lerna version/publish so CI no longer tries to recreate the existing `@studio-helga/valculator-app@1.1.0` tag
- Mark the app package private and ignore `packages/interface/**` for version change detection
- Sync `@valculator/theme` to `0.3.2` to match the existing tag and avoid the same collision

## Test plan
- [ ] Merge to `main` and confirm the Publish workflow `lerna version` step completes without the duplicate-tag error
- [ ] Confirm `@studio-helga/valculator-app` is not included in the versioned packages list
- [ ] Confirm other packages (e.g. `@valculator/data`) still version as expected


Made with [Cursor](https://cursor.com)