### PR TITLE
fix: make publish workflow reliable without versioning the app

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,40 +6,46 @@ on:
       - main
 
 concurrency: main
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    steps: 
-    - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v4
       with:
         ref: ${{ github.ref }}
         fetch-depth: 0
+        persist-credentials: true
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Use Node.js 18.x
       uses: actions/setup-node@v4
       with:
         node-version: 18.x
         registry-url: 'https://registry.npmjs.org'
-        scope: "@studio-helga"
+        scope: '@valculator'
         always-auth: true
+
+    - name: Install Dependencies
+      run: yarn install
 
     - name: Version
       env:
         NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.name "${{ github.actor }}"
-        git config user.email "${{ github.actor}}@users.noreply.github.com"
-        npx lerna version --conventional-commits --yes
-        
-    - name: Install Dependencies
+        git config user.email "${{ github.actor }}@users.noreply.github.com"
+        yarn lerna version --conventional-commits --yes
+
+    - name: Install after version bump
       run: yarn install
-    
+
     - name: Build
       run: yarn build
 
     - name: Publish
-      run: npx lerna publish from-package --yes
-      env: 
+      run: yarn lerna publish from-package --yes
+      env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         git config user.name "${{ github.actor }}"
         git config user.email "${{ github.actor}}@users.noreply.github.com"
-        npx lerna version --conventional-commits --yes --ignore '@studio-helga/valculator-app'
+        npx lerna version --conventional-commits --yes
         
     - name: Install Dependencies
       run: yarn install
@@ -40,6 +40,6 @@ jobs:
       run: yarn build
 
     - name: Publish
-      run: npx lerna publish from-package --yes --ignore '@studio-helga/valculator-app'
+      run: npx lerna publish from-package --yes
       env: 
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -1,13 +1,18 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "version": "independent",
-  "packages": ["packages/*"],
+  "packages": [
+    "packages/cdk",
+    "packages/context",
+    "packages/data",
+    "packages/images",
+    "packages/theme"
+  ],
   "npmClient": "yarn",
   "command": {
     "version": {
       "allowBranch": ["main"],
-      "conventionalCommits": true,
-      "ignoreChanges": ["packages/interface/**"]
+      "conventionalCommits": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "scripts": {
     "dev": "yarn workspace @studio-helga/valculator-app dev",
-    "lint": "lerna run lint",
+    "lint": "lerna run lint && yarn workspace @studio-helga/valculator-app lint",
     "test:circular": "yarn workspaces foreach --all -p run test:circular",
-    "build": "lerna run build",
+    "build": "lerna run build && yarn workspace @studio-helga/valculator-app build",
     "deploy:images": "yarn workspace cdk run cdk deploy"
   },
   "packageManager": "yarn@4.1.0",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -2,7 +2,7 @@
   "name": "@studio-helga/valculator-app",
   "author": "Charlotte Hughes <hues.charlotte@gmail.com>",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "main": "dist/entry-interface.js",
   "exports": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@valculator/theme",
-  "private": true,
   "version": "0.3.2",
   "type": "module",
   "main": "src/main.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": "./src/main.ts"


### PR DESCRIPTION
## Summary
- Exclude unused `@studio-helga/valculator-app` from Lerna entirely (still available as a Yarn workspace for local dev/build)
- Stop using `npx lerna` (which pulled latest 8.2.4 and broke on `--ignore`); install first and run `yarn lerna`
- Harden checkout (`actions/checkout@v4` + credentials) so version commits/tags can push
- Restore `@valculator/theme` as the public npm package (already published through 0.3.1); keep data/context/images private
- Sync app package version to existing `1.1.0` tag

## Test plan
- [ ] Merge to `main`
- [ ] Confirm Publish workflow Version step succeeds and does **not** mention `@studio-helga/valculator-app`
- [ ] Confirm version bumps land for changed packages (e.g. `@valculator/data`)
- [ ] Confirm `@valculator/theme` publishes to npm if it has a new version
- [ ] Confirm private packages are not published