### PR TITLE
fix: publish from package.json only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,7 @@ on:
 
 concurrency: main
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   publish:
@@ -16,10 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.ref }}
         fetch-depth: 0
-        persist-credentials: true
-        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Use Node.js 18.x
       uses: actions/setup-node@v4
@@ -30,34 +26,6 @@ jobs:
         always-auth: true
 
     - name: Install Dependencies
-      run: yarn install
-
-    - name: Version
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git config user.name "${{ github.actor }}"
-        git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-        if [ "$(yarn lerna changed --json 2>/dev/null | jq 'length')" = "0" ]; then
-          echo "No packages to version"
-          exit 0
-        fi
-
-        # Branch protection blocks direct pushes to main, so version locally,
-        # push tags, then land the bump via an auto-merged PR.
-        yarn lerna version --conventional-commits --yes --no-push \
-          --message "chore: publish versions [skip ci]"
-
-        git push origin --tags
-
-        BRANCH="chore/lerna-publish-$(git rev-parse --short HEAD)"
-        git push origin "HEAD:refs/heads/${BRANCH}"
-        PR_URL="$(gh pr create --base main --head "${BRANCH}" --title "chore: publish versions" --body "Automated package version bump from the publish workflow.")"
-        gh pr merge "${PR_URL}" --admin --merge --delete-branch
-
-    - name: Install after version bump
       run: yarn install
 
     - name: Build

--- a/packages/context/CHANGELOG.md
+++ b/packages/context/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/charlotte-hues/valculator/compare/@valculator/context@0.1.3...@valculator/context@0.1.4) (2026-07-17)
+
+**Note:** Version bump only for package @valculator/context
+
+
+
+
+
 ## [0.1.3](https://github.com/charlotte-hues/valculator/compare/@valculator/context@0.1.2...@valculator/context@0.1.3) (2026-07-17)
 
 **Note:** Version bump only for package @valculator/context

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valculator/context",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "exports": {
     ".": {
@@ -20,7 +20,7 @@
     "test:circular": "madge --extensions ts,tsx ./src/ -c"
   },
   "dependencies": {
-    "@valculator/data": "^0.1.3",
+    "@valculator/data": "^0.1.4",
     "lz-string": "^1.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.4](https://github.com/charlotte-hues/valculator/compare/@valculator/data@0.1.3...@valculator/data@0.1.4) (2026-07-17)
+
+**Note:** Version bump only for package @valculator/data
+
+
+
+
+
 ## [0.1.3](https://github.com/charlotte-hues/valculator/compare/@valculator/data@0.1.2...@valculator/data@0.1.3) (2026-07-17)
 
 **Note:** Version bump only for package @valculator/data

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valculator/data",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/charlotte-hues/valculator/compare/@valculator/images@0.3.3...@valculator/images@0.3.4) (2026-07-17)
+
+**Note:** Version bump only for package @valculator/images
+
+
+
+
+
 ## [0.3.3](https://github.com/charlotte-hues/valculator/compare/@valculator/images@0.3.2...@valculator/images@0.3.3) (2026-07-17)
 
 **Note:** Version bump only for package @valculator/images

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valculator/images",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "main": "src/main.ts",
   "scripts": {
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@valculator/data": "^0.1.3",
+    "@valculator/data": "^0.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/theme/CHANGELOG.md
+++ b/packages/theme/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.3.4](https://github.com/charlotte-hues/valculator/compare/@valculator/theme@0.3.3...@valculator/theme@0.3.4) (2026-07-17)
+
+**Note:** Version bump only for package @valculator/theme
+
+
+
+
+
 ## [0.3.3](https://github.com/charlotte-hues/valculator/compare/@valculator/theme@0.3.1...@valculator/theme@0.3.3) (2026-07-17)
 
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@valculator/theme",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "main": "src/main.ts",
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,7 +2336,7 @@ __metadata:
     "@types/react-dom": "npm:^18.2.19"
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
     "@typescript-eslint/parser": "npm:^6.21.0"
-    "@valculator/data": "npm:^0.1.3"
+    "@valculator/data": "npm:^0.1.4"
     "@vitejs/plugin-react": "npm:^4.2.1"
     eslint: "npm:^8.56.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"
@@ -2353,7 +2353,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@valculator/data@npm:^0.1.3, @valculator/data@workspace:packages/data":
+"@valculator/data@npm:^0.1.4, @valculator/data@workspace:packages/data":
   version: 0.0.0-use.local
   resolution: "@valculator/data@workspace:packages/data"
   dependencies:
@@ -2372,7 +2372,7 @@ __metadata:
     "@types/react-dom": "npm:^18.2.19"
     "@typescript-eslint/eslint-plugin": "npm:^6.21.0"
     "@typescript-eslint/parser": "npm:^6.21.0"
-    "@valculator/data": "npm:^0.1.3"
+    "@valculator/data": "npm:^0.1.4"
     "@vitejs/plugin-react": "npm:^4.2.1"
     eslint: "npm:^8.56.0"
     eslint-plugin-react-hooks: "npm:^4.6.0"


### PR DESCRIPTION
## Summary
- Sync package versions on main with the tags already created (`theme@0.3.4`, `data@0.1.4`, etc.)
- Stop running `lerna version` on push to `main` (branch protection + Actions cannot create PRs with the default token)
- Keep `yarn lerna publish from-package` so public packages like `@valculator/theme` still publish to npm

Version bumps should be done in normal PRs (or a future manual release workflow), not by pushing commits to `main` from CI.

## Test plan
- [ ] Merge this PR
- [ ] Confirm Publish workflow succeeds
- [ ] Confirm `npm view @valculator/theme version` is `0.3.4`


Made with [Cursor](https://cursor.com)