### PR TITLE
fix: publish @studio-helga/valculator-app to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version: 18.x
         registry-url: 'https://registry.npmjs.org'
-        scope: '@valculator'
+        scope: '@studio-helga'
         always-auth: true
 
     - name: Install Dependencies

--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,7 @@
     "packages/context",
     "packages/data",
     "packages/images",
+    "packages/interface",
     "packages/theme"
   ],
   "npmClient": "yarn",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "scripts": {
     "dev": "yarn workspace @studio-helga/valculator-app dev",
-    "lint": "lerna run lint && yarn workspace @studio-helga/valculator-app lint",
+    "lint": "lerna run lint",
     "test:circular": "yarn workspaces foreach --all -p run test:circular",
-    "build": "lerna run build && yarn workspace @studio-helga/valculator-app build",
+    "build": "lerna run build",
     "deploy:images": "yarn workspace cdk run cdk deploy"
   },
   "packageManager": "yarn@4.1.0",

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -1,10 +1,12 @@
 {
   "name": "@studio-helga/valculator-app",
   "author": "Charlotte Hughes <hues.charlotte@gmail.com>",
-  "private": true,
   "version": "1.1.0",
   "type": "module",
   "main": "dist/entry-interface.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": "./dist/entry-interface.js",


### PR DESCRIPTION
## Summary
- Put `packages/interface` back in Lerna
- Make `@studio-helga/valculator-app` public at `1.1.0` (npm still only has `1.0.0`)
- Point the publish workflow auth scope at `@studio-helga`

## Test plan
- [ ] Merge to `main`
- [ ] Confirm Publish workflow succeeds
- [ ] Confirm `npm view @studio-helga/valculator-app version` is `1.1.0`


Made with [Cursor](https://cursor.com)