### PR TITLE
chore: schedule interface patch for Fenris data

### DIFF
--- a/.changeset/update-fenris-crafting-materials.md
+++ b/.changeset/update-fenris-crafting-materials.md
@@ -1,0 +1,5 @@
+---
+"@valculator/interface": patch
+---
+
+Update Fenris equipment crafting material requirements.


### PR DESCRIPTION
The Fenris crafting updates are already on main and bundled into @valculator/interface, so this changeset versions the public package without publishing private data.